### PR TITLE
remove sort query params

### DIFF
--- a/addon/mixins/url-templates.js
+++ b/addon/mixins/url-templates.js
@@ -58,15 +58,6 @@ export default Mixin.create({
     return EmberObject.create(this.get('urlSegments'));
   },
 
-  // HACK: Prevent query/queryRecord from appending query params to urls, we
-  // can do that in the template.
-  // TODO: ember-data plans to implement better hooks for customizing the
-  // request. Hopefully in the future, this hack can be removed and another
-  // hook used instead.
-  sortQueryParams(/* params */) {
-    return {};
-  },
-
   _urlFromLink(snapshot, urlTemplate) {
     if (LINK_PREFIX_RE.test(urlTemplate)) {
       return this.buildURL(null, snapshot.id, snapshot, urlTemplate.replace(LINK_PREFIX_RE, ''), {});

--- a/tests/acceptance/basic-url-template-test.js
+++ b/tests/acceptance/basic-url-template-test.js
@@ -50,24 +50,4 @@ module('Acceptance | basic url template', function(hooks) {
     assert.equal(findAll('#post-2').length, 1);
     assert.equal(findAll('#post-3').length, 0);
   });
-
-  test('it prevents ember-data from adding query params', async function(assert) {
-    server.create('post', {
-      slug: 'my-first-post',
-      title: 'This is my first post',
-    });
-
-    let queryParams, params;
-
-    server.get('/my-posts/:slug', (schema, request) => {
-      queryParams = request.queryParams;
-      params = request.params;
-      return schema.posts.findBy({ slug: request.params.slug });
-    });
-
-    await visit('/posts/my-first-post');
-
-    assert.equal(params.slug, 'my-first-post');
-    assert.ok(!queryParams.foo);
-  });
 });


### PR DESCRIPTION
- this override is incompatible with use of certain mocking libraries and blows away query params in those cases
- removing here since the underlying PR has been merged